### PR TITLE
[FEAT] 엔티티 코드 작성

### DIFF
--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/build.gradle
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.postgresql:postgresql'
+    testRuntimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/DomainCoreRdbApplication.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/DomainCoreRdbApplication.java
@@ -1,0 +1,11 @@
+package org.myeonjeobjjang.domain;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DomainCoreRdbApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DomainCoreRdbApplication.class, args);
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/common/BaseEntity.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/common/BaseEntity.java
@@ -1,0 +1,30 @@
+package org.myeonjeobjjang.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    public void delete() {
+        deletedAt = LocalDateTime.now();
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/config/CoreJpaConfig.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/config/CoreJpaConfig.java
@@ -1,0 +1,10 @@
+package org.myeonjeobjjang.domain.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class CoreJpaConfig {
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/company/entity/Company.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/company/entity/Company.java
@@ -1,0 +1,29 @@
+package org.myeonjeobjjang.domain.core.company.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.industry.entity.Industry;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Company extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long companyId;
+    private String companyName;
+    private String companyInformation;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Industry industry;
+
+    @Builder
+    private Company(String companyName, String companyInformation, Industry industry) {
+        this.companyName = companyName;
+        this.companyInformation = companyInformation;
+        this.industry = industry;
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/company/repository/CompanyRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/company/repository/CompanyRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.company.repository;
+
+import org.myeonjeobjjang.domain.core.company.entity.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRepository extends JpaRepository<Company,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversation/entity/Conversation.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversation/entity/Conversation.java
@@ -1,0 +1,32 @@
+package org.myeonjeobjjang.domain.core.conversation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.coverLetter.entity.CoverLetter;
+import org.myeonjeobjjang.domain.core.member.entity.Member;
+import org.myeonjeobjjang.domain.core.resume.entity.Resume;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Conversation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long conversationId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private CoverLetter coverLetter;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Resume resume;
+
+    public Conversation(Member member, CoverLetter coverLetter, Resume resume) {
+        this.member = member;
+        this.coverLetter = coverLetter;
+        this.resume = resume;
+    }
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversation/repository/ConversationRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversation/repository/ConversationRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.conversation.repository;
+
+import org.myeonjeobjjang.domain.core.conversation.entity.Conversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversationRepository extends JpaRepository<Conversation,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/entity/ConversationLog.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/entity/ConversationLog.java
@@ -1,0 +1,34 @@
+package org.myeonjeobjjang.domain.core.conversationLog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.conversation.entity.Conversation;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConversationLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long conversatoinLogId;
+    @JoinColumn(updatable = false)
+    @ManyToOne
+    private Conversation conversation;
+    @Column(updatable = false, columnDefinition = "TEXT")
+    private String data;
+    @Column(updatable = false)
+    @Enumerated(EnumType.STRING)
+    private ConversationMessageType messageType;
+
+    @Builder
+    private ConversationLog(Conversation conversation, String data, ConversationMessageType messageType) {
+        this.conversation = conversation;
+        this.data = data;
+        this.messageType = messageType;
+    }
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/entity/ConversationMessageType.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/entity/ConversationMessageType.java
@@ -1,0 +1,29 @@
+package org.myeonjeobjjang.domain.core.conversationLog.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ConversationMessageType {
+    USER("user"),
+    ASSISTANT("assistant"),
+    SYSTEM("system"),
+    TOOL("tool"),
+    ;
+    private final String value;
+
+    private ConversationMessageType(String value) {
+        this.value = value;
+    }
+
+    public static ConversationMessageType fromValue(String value) {
+        ConversationMessageType[] values = values();
+        for (int i = 0; i < values.length; ++i) {
+            ConversationMessageType messageType = values[i];
+            if (messageType.getValue().equals(value)) {
+                return messageType;
+            }
+        }
+
+        throw new IllegalArgumentException("Invalid ConversationMessageType value: " + value);
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/repository/ConversationLogRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/repository/ConversationLogRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.conversationLog.repository;
+
+import org.myeonjeobjjang.domain.core.conversationLog.entity.ConversationLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversationLogRepository extends JpaRepository<ConversationLog,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/entity/CoverLetter.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/entity/CoverLetter.java
@@ -1,0 +1,30 @@
+package org.myeonjeobjjang.domain.core.coverLetter.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.member.entity.Member;
+import org.myeonjeobjjang.domain.core.jobPosting.entity.JobPosting;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoverLetter extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long applicationId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private JobPosting jobPosting;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Builder
+    private CoverLetter(JobPosting recruitment, Member member) {
+        this.jobPosting = recruitment;
+        this.member = member;
+    }
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/repository/CoverLetterRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/repository/CoverLetterRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.coverLetter.repository;
+
+import org.myeonjeobjjang.domain.core.coverLetter.entity.CoverLetter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverLetterRepository extends JpaRepository<CoverLetter,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetterItem/entity/CoverLetterItem.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetterItem/entity/CoverLetterItem.java
@@ -1,0 +1,30 @@
+package org.myeonjeobjjang.domain.core.coverLetterItem.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.coverLetter.entity.CoverLetter;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoverLetterItem extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long applicationItemId;
+    @Column(columnDefinition = "TEXT")
+    private String question;
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private CoverLetter application;
+
+    public CoverLetterItem(String question, String answer, CoverLetter application) {
+        this.question = question;
+        this.answer = answer;
+        this.application = application;
+    }
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetterItem/repository/CoverLetterItemRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/coverLetterItem/repository/CoverLetterItemRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.coverLetterItem.repository;
+
+import org.myeonjeobjjang.domain.core.coverLetterItem.entity.CoverLetterItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverLetterItemRepository extends JpaRepository<CoverLetterItem,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/industry/entity/Industry.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/industry/entity/Industry.java
@@ -1,0 +1,26 @@
+package org.myeonjeobjjang.domain.core.industry.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Industry extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long industryId;
+    private String industryName;
+    @Column(columnDefinition = "TEXT")
+    private String industryInformation;
+
+    @Builder
+    private Industry(String industryName, String industryInformation) {
+        this.industryName = industryName;
+        this.industryInformation = industryInformation;
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/industry/repository/IndustryRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/industry/repository/IndustryRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.industry.repository;
+
+import org.myeonjeobjjang.domain.core.industry.entity.Industry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IndustryRepository extends JpaRepository<Industry, Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobCoverLetterQuestion/entity/JobCoverLetterQuestion.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobCoverLetterQuestion/entity/JobCoverLetterQuestion.java
@@ -1,0 +1,29 @@
+package org.myeonjeobjjang.domain.core.jobCoverLetterQuestion.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.jobDescription.entity.JobDescription;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobCoverLetterQuestion extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long recruitmentQuestionId;
+    @Column(columnDefinition = "TEXT")
+    private String question;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private JobDescription jobDescription;
+
+    @Builder
+    private JobCoverLetterQuestion(String question, JobDescription jobDescription) {
+        this.question = question;
+        this.jobDescription = jobDescription;
+    }
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobCoverLetterQuestion/repository/JobCoverLetterQuestionRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobCoverLetterQuestion/repository/JobCoverLetterQuestionRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.jobCoverLetterQuestion.repository;
+
+import org.myeonjeobjjang.domain.core.jobCoverLetterQuestion.entity.JobCoverLetterQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobCoverLetterQuestionRepository extends JpaRepository<JobCoverLetterQuestion,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobDescription/entity/JobDescription.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobDescription/entity/JobDescription.java
@@ -1,0 +1,31 @@
+package org.myeonjeobjjang.domain.core.jobDescription.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.jobPosting.entity.JobPosting;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobDescription extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long jobDescriptionId;
+    private String jobName;
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private JobPosting recruitment;
+
+    @Builder
+    private JobDescription(String jobName, String description, JobPosting recruitment) {
+        this.jobName = jobName;
+        this.description = description;
+        this.recruitment = recruitment;
+    }
+}
+

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobDescription/repository/JobDescriptionRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobDescription/repository/JobDescriptionRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.jobDescription.repository;
+
+import org.myeonjeobjjang.domain.core.jobDescription.entity.JobDescription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobDescriptionRepository extends JpaRepository<JobDescription,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobPosting/entity/JobPosting.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobPosting/entity/JobPosting.java
@@ -1,0 +1,34 @@
+package org.myeonjeobjjang.domain.core.jobPosting.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.company.entity.Company;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobPosting extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long recruitmentId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Company company;
+    private String jobPostingName;
+    @Column(columnDefinition = "TEXT")
+    private String jobPostingDescription;
+    private LocalDateTime duedate;
+
+    @Builder
+    private JobPosting(Company company, String jobPostingName, String jobPostingDescription, LocalDateTime duedate) {
+        this.company = company;
+        this.jobPostingName = jobPostingName;
+        this.jobPostingDescription = jobPostingDescription;
+        this.duedate = duedate;
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobPosting/repository/JobPostingRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/jobPosting/repository/JobPostingRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.jobPosting.repository;
+
+import org.myeonjeobjjang.domain.core.jobPosting.entity.JobPosting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobPostingRepository extends JpaRepository<JobPosting,Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/member/entity/Member.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/member/entity/Member.java
@@ -1,0 +1,28 @@
+package org.myeonjeobjjang.domain.core.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+    private String userName;
+    @Column(updatable = false)
+    private String email;
+    private String password;
+
+    @Builder
+    private Member(String userName, String email, String password) {
+        this.userName = userName;
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/member/repository/MemberRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.member.repository;
+
+import org.myeonjeobjjang.domain.core.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/resume/entity/Resume.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/resume/entity/Resume.java
@@ -1,0 +1,47 @@
+package org.myeonjeobjjang.domain.core.resume.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Resume extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long portfolioId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+    @Column(columnDefinition = "TEXT")
+    private String introduce;
+    private String major;
+    private String grade;
+    @Column(columnDefinition = "TEXT")
+    private String skill;
+    @Column(columnDefinition = "TEXT")
+    private String compnayExperience;
+    @Column(columnDefinition = "TEXT")
+    private String activity;
+    @Column(columnDefinition = "TEXT")
+    private String certificate;
+    @Column(columnDefinition = "TEXT")
+    private String price;
+
+    @Builder
+    private Resume(String price, String certificate, String activity, String compnayExperience, String skill, String grade, String major, String introduce, Member member) {
+        this.price = price;
+        this.certificate = certificate;
+        this.activity = activity;
+        this.compnayExperience = compnayExperience;
+        this.skill = skill;
+        this.grade = grade;
+        this.major = major;
+        this.introduce = introduce;
+        this.member = member;
+    }
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/resume/repository/ResumeRepository.java
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/java/org/myeonjeobjjang/domain/core/resume/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package org.myeonjeobjjang.domain.core.resume.repository;
+
+import org.myeonjeobjjang.domain.core.resume.entity.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/resources/application.yml
+++ b/myeonjeobjjang-domain/myeonjeobjjang-domain-core-rdb/src/main/resources/application.yml
@@ -1,13 +1,14 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL
+    url: jdbc:postgresql://127.0.0.1:5472/rag-project-vectordb
+    username: rag-project
+    password: 12341234
+    driver-class-name: org.postgresql.Driver
   jpa:
+    show-sql: false
+    database: postgresql
     hibernate:
       ddl-auto: update
-    show-sql: true
     properties:
       hibernate:
         format_sql: true
-  h2:
-    console:
-      enabled: true


### PR DESCRIPTION
## PR 타입
- 기능 추가
## 반영 브랜치
feat/#6/entitySetting -> develop
## 변경사항
![image](https://github.com/user-attachments/assets/af375c36-d2a1-42f1-8a31-6fe812c3c0b7)
## 개발 회고
- 현재로써는 RDB를 사용하는 두 모듈 domain-chat-rdb와 domain-core-rdb를 나눌 필요가 없을것같다.
  - ai-agent에서 domain-chat-rdb에서 사용하지 않는 domain-core-rdb의 엔티티들에 대한 코드를 추가한다고 해서 성능상에 큰 문제가 발생하지도 않을것으로 보이기 때문이다.
  - 이것은 비즈니스 코드와 기존의 구현한 기술을 합치는 과정에서 처리할것이다.