### PR TITLE
[FEAT] 툴기반, ReAct 패턴 Agent 구현

### DIFF
--- a/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/java/org/myeonjeobjjang/applicant/conversation/ConversationApplicantController.java
+++ b/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/java/org/myeonjeobjjang/applicant/conversation/ConversationApplicantController.java
@@ -61,6 +61,7 @@ public class ConversationApplicantController {
         ));
     }
 
+    @Deprecated
     @PostMapping("/{conversationId}/react")
     public ResponseEntity<String> mockInterviewReActChat(
         @AuthenticationPrincipal PrincipalDetails principalDetails,

--- a/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/java/org/myeonjeobjjang/applicant/conversation/ConversationApplicantController.java
+++ b/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/java/org/myeonjeobjjang/applicant/conversation/ConversationApplicantController.java
@@ -22,8 +22,8 @@ public class ConversationApplicantController {
     @PostMapping("/coverLetters/{coverLetterId}/resumes/{resumeId}")
     public ResponseEntity<ConversationCreateResponse> create(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @PathVariable Long coverLetterId,
-        @PathVariable Long resumeId
+        @PathVariable(name = "coverLetterId") Long coverLetterId,
+        @PathVariable(name = "resumeId") Long resumeId
     ) {
         Member member = principalDetails.getMember();
         return ResponseEntity.ok(conversationService.create(member, coverLetterId, resumeId));
@@ -33,7 +33,7 @@ public class ConversationApplicantController {
     public String mockInterviewChat(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestBody @Validated MockInterviewChatApplicantRequest request,
-        @PathVariable Long conversationId
+        @PathVariable(name = "conversationId") Long conversationId
     ) {
         Member member = principalDetails.getMember();
         return conversationService.mockInterviewChat(member, request.userMessage(), conversationId);
@@ -45,5 +45,19 @@ public class ConversationApplicantController {
         @RequestBody @Validated ConversationLogsApplicantResponse request
     ) {
         return ResponseEntity.ok(conversationService.noOffsetGetConversationLog(conversationId, request.lastConversationCreatedAt(), request.amount()));
+    }
+
+    @PostMapping("/{conversationId}/tools")
+    public ResponseEntity<String> mockInterviewToolsChat(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody @Validated MockInterviewChatApplicantRequest request,
+        @PathVariable(name = "conversationId") Long conversationId
+    ) {
+        Member member = principalDetails.getMember();
+        return ResponseEntity.ok(conversationService.mockInterviewToolsChat(
+            member,
+            request.userMessage(),
+            conversationId
+        ));
     }
 }

--- a/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/java/org/myeonjeobjjang/applicant/conversation/ConversationApplicantController.java
+++ b/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/java/org/myeonjeobjjang/applicant/conversation/ConversationApplicantController.java
@@ -60,4 +60,18 @@ public class ConversationApplicantController {
             conversationId
         ));
     }
+
+    @PostMapping("/{conversationId}/react")
+    public ResponseEntity<String> mockInterviewReActChat(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody @Validated MockInterviewChatApplicantRequest request,
+        @PathVariable(name = "conversationId") Long conversationId
+    ) {
+        Member member = principalDetails.getMember();
+        return ResponseEntity.ok(conversationService.mockInterviewReActChat(
+            member,
+            request.userMessage(),
+            conversationId
+        ));
+    }
 }

--- a/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/resources/application-boot-api.yml
+++ b/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/resources/application-boot-api.yml
@@ -1,0 +1,9 @@
+logging:
+  level:
+    root: debug
+spring:
+  config:
+    import: 'classpath:application-integration.yml'
+  ai:
+    openai:
+      api-key: ${OPENAI_APIKEY}

--- a/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/resources/application.yml
+++ b/myeonjeobjjang-boot/myeonjeobjjang-boot-api/src/main/resources/application.yml
@@ -1,9 +1,3 @@
-logging:
-  level:
-    root: debug
 spring:
   config:
-    import: 'classpath:application-integration.yml'
-  ai:
-    openai:
-      api-key: ${OPENAI_APIKEY}
+    import: 'classpath:application-boot-api.yml'

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/entity/Conversation.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/entity/Conversation.java
@@ -6,7 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.myeonjeobjjang.domain.common.BaseEntity;
+import org.myeonjeobjjang.domain.core.company.entity.Company;
 import org.myeonjeobjjang.domain.core.coverLetter.entity.CoverLetter;
+import org.myeonjeobjjang.domain.core.industry.entity.Industry;
+import org.myeonjeobjjang.domain.core.jobDescription.entity.JobDescription;
+import org.myeonjeobjjang.domain.core.jobPosting.entity.JobPosting;
 import org.myeonjeobjjang.domain.core.member.entity.Member;
 import org.myeonjeobjjang.domain.core.resume.entity.Resume;
 
@@ -20,31 +24,41 @@ public class Conversation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cover_letter_id")
     private CoverLetter coverLetter;
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "resume_id")
     private Resume resume;
-    @Column(columnDefinition = "TEXT")
-    private String industryInfo;
-    @Column(columnDefinition = "TEXT")
-    private String companyInfo;
-    @Column(columnDefinition = "TEXT")
-    private String jobDescriptionInfo;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "industry_id")
+    private Industry industry;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "compnay_id")
+    private Company company;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_description_id")
+    private JobDescription jobDescription;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_posting_id")
+    private JobPosting jobPosting;
 
     @Builder
     private Conversation(
         Member member,
         CoverLetter coverLetter,
         Resume resume,
-        String industryInfo,
-        String companyInfo,
-        String jobDescriptionInfo
+        Industry industry,
+        Company company,
+        JobDescription jobDescription,
+        JobPosting jobPosting
     ) {
         this.member = member;
         this.coverLetter = coverLetter;
         this.resume = resume;
-        this.industryInfo = industryInfo;
-        this.companyInfo = companyInfo;
-        this.jobDescriptionInfo = jobDescriptionInfo;
+        this.industry = industry;
+        this.company = company;
+        this.jobDescription = jobDescription;
+        this.jobPosting = jobPosting;
     }
 }
 

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationService.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationService.java
@@ -12,4 +12,6 @@ public interface ConversationService {
     String mockInterviewChat(Member member, String userMessage, Long conversationId);
 
     ConversationLogNoOffsetGetResponse noOffsetGetConversationLog(Long conversationId, LocalDateTime lastConversationCreatedAt, Integer amount);
+
+    String mockInterviewToolsChat(Member member, String userMessage, Long conversationId);
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationService.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationService.java
@@ -14,4 +14,6 @@ public interface ConversationService {
     ConversationLogNoOffsetGetResponse noOffsetGetConversationLog(Long conversationId, LocalDateTime lastConversationCreatedAt, Integer amount);
 
     String mockInterviewToolsChat(Member member, String userMessage, Long conversationId);
+
+    String mockInterviewReActChat(Member member, String userMessage, Long conversationId);
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationService.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationService.java
@@ -15,5 +15,6 @@ public interface ConversationService {
 
     String mockInterviewToolsChat(Member member, String userMessage, Long conversationId);
 
+    @Deprecated
     String mockInterviewReActChat(Member member, String userMessage, Long conversationId);
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationServiceImpl.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationServiceImpl.java
@@ -13,7 +13,8 @@ import org.myeonjeobjjang.domain.core.resume.entity.Resume;
 import org.myeonjeobjjang.domain.core.resume.service.ResumeService;
 import org.myeonjeobjjang.domain.core.vectordb.VectorDBService;
 import org.myeonjeobjjang.exception.BaseException;
-import org.myeonjeobjjang.infra.client.mockInterview.MockInterviewClient;
+import org.myeonjeobjjang.infra.client.mockInterview.MockInterviewOpenAiClient;
+import org.myeonjeobjjang.infra.client.mockInterview.MockInterviewOpenAiToolClient;
 import org.myeonjeobjjang.infra.client.mockInterview.dto.MockInterviewClientRequest.MockInterviewChatRequest;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +30,8 @@ public class ConversationServiceImpl implements ConversationService {
     private final CoverLetterService coverLetterService;
     private final ResumeService resumeService;
     private final VectorDBService vectorDBService;
-    private final MockInterviewClient mockInterviewClient;
+    private final MockInterviewOpenAiClient mockInterviewOpenAiClient;
+    private final MockInterviewOpenAiToolClient mockInterviewOpenAiToolClient;
     private final ConversationLogService conversationLogService;
 
     private final String MOCK_INTERVIEW_CONVERSATION_PREFIX = "MOCK_INTERVIEW_";
@@ -42,15 +44,16 @@ public class ConversationServiceImpl implements ConversationService {
             .member(member)
             .coverLetter(projectionResponse.getCoverLetter())
             .resume(resume)
-            .industryInfo(projectionResponse.getIndustryName() + " : " + projectionResponse.getIndustryInformation())
-            .companyInfo(projectionResponse.getCompanyName() + " : " + projectionResponse.getCompanyInformation())
-            .jobDescriptionInfo(projectionResponse.getJobName() + " : " + projectionResponse.getDescription())
+            .industry(projectionResponse.getIndustry())
+            .company(projectionResponse.getCompany())
+            .jobDescription(projectionResponse.getJobDescription())
+            .jobPosting(projectionResponse.getJobPosting())
             .build();
         Conversation savedConversation = conversationRepository.save(newConversation);
         return ConversationCreateResponse.toDto(
-            newConversation.getConversationId(),
-            coverLetterService.embeddingCoverLetter(coverLetterId, savedConversation.getConversationId()),
-            vectorDBService.resumeEmbedding(resume, savedConversation.getConversationId())
+            savedConversation.getConversationId(),
+            coverLetterService.embeddingCoverLetter(coverLetterId, MOCK_INTERVIEW_CONVERSATION_PREFIX + savedConversation.getConversationId()),
+            vectorDBService.resumeEmbedding(resume, MOCK_INTERVIEW_CONVERSATION_PREFIX + savedConversation.getConversationId())
         );
     }
 
@@ -59,7 +62,18 @@ public class ConversationServiceImpl implements ConversationService {
         Conversation conversation = conversationRepository.findByConversationIdAndMember(conversationId, member)
             .orElseThrow(() -> new BaseException(CONVERSATION_NOT_FOUND));
 
-        return mockInterviewClient.mockInterviewChat(MockInterviewChatRequest.toDto(
+        return mockInterviewOpenAiClient.mockInterviewChat(MockInterviewChatRequest.toDto(
+            userMessage,
+            conversation,
+            MOCK_INTERVIEW_CONVERSATION_PREFIX
+        ));
+    }
+
+    @Override
+    public String mockInterviewToolsChat(Member member, String userMessage, Long conversationId) {
+        Conversation conversation = conversationRepository.findByConversationIdAndMember(conversationId, member)
+            .orElseThrow(() -> new BaseException(CONVERSATION_NOT_FOUND));
+        return mockInterviewOpenAiToolClient.mockInterviewChat(MockInterviewChatRequest.toDto(
             userMessage,
             conversation,
             MOCK_INTERVIEW_CONVERSATION_PREFIX

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationServiceImpl.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversation/service/ConversationServiceImpl.java
@@ -14,6 +14,7 @@ import org.myeonjeobjjang.domain.core.resume.service.ResumeService;
 import org.myeonjeobjjang.domain.core.vectordb.VectorDBService;
 import org.myeonjeobjjang.exception.BaseException;
 import org.myeonjeobjjang.infra.client.mockInterview.MockInterviewOpenAiClient;
+import org.myeonjeobjjang.infra.client.mockInterview.MockInterviewOpenAiReActClient;
 import org.myeonjeobjjang.infra.client.mockInterview.MockInterviewOpenAiToolClient;
 import org.myeonjeobjjang.infra.client.mockInterview.dto.MockInterviewClientRequest.MockInterviewChatRequest;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,7 @@ public class ConversationServiceImpl implements ConversationService {
     private final VectorDBService vectorDBService;
     private final MockInterviewOpenAiClient mockInterviewOpenAiClient;
     private final MockInterviewOpenAiToolClient mockInterviewOpenAiToolClient;
+    private final MockInterviewOpenAiReActClient mockInterviewOpenAiReActClient;
     private final ConversationLogService conversationLogService;
 
     private final String MOCK_INTERVIEW_CONVERSATION_PREFIX = "MOCK_INTERVIEW_";
@@ -74,6 +76,17 @@ public class ConversationServiceImpl implements ConversationService {
         Conversation conversation = conversationRepository.findByConversationIdAndMember(conversationId, member)
             .orElseThrow(() -> new BaseException(CONVERSATION_NOT_FOUND));
         return mockInterviewOpenAiToolClient.mockInterviewChat(MockInterviewChatRequest.toDto(
+            userMessage,
+            conversation,
+            MOCK_INTERVIEW_CONVERSATION_PREFIX
+        ));
+    }
+
+    @Override
+    public String mockInterviewReActChat(Member member, String userMessage, Long conversationId) {
+        Conversation conversation = conversationRepository.findByConversationIdAndMember(conversationId, member)
+            .orElseThrow(() -> new BaseException(CONVERSATION_NOT_FOUND));
+        return mockInterviewOpenAiReActClient.mockInterviewChat(MockInterviewChatRequest.toDto(
             userMessage,
             conversation,
             MOCK_INTERVIEW_CONVERSATION_PREFIX

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/repository/ConversationLogRepository.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/conversationLog/repository/ConversationLogRepository.java
@@ -14,10 +14,10 @@ public interface ConversationLogRepository extends JpaRepository<ConversationLog
         select cl
         from ConversationLog cl
         where cl.conversationId = :conversationId and cl.deletedAt is null
-        order by cl.createdAt DESC
+        order by cl.createdAt ASC
         limit :lastN
         """)
-    List<ConversationLog> findAllByConversationId(String conversationId, int lastN);
+    List<ConversationLog> findAllByConversationId(@Param("conversationId") String conversationId, @Param("lastN") int lastN);
 
     void deleteAllByConversationId(String conversationId);
 

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/repository/CoverLetterRepository.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/repository/CoverLetterRepository.java
@@ -7,6 +7,7 @@ import org.myeonjeobjjang.domain.core.jobDescription.entity.JobDescription;
 import org.myeonjeobjjang.domain.core.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,17 +32,15 @@ public interface CoverLetterRepository extends JpaRepository<CoverLetter,Long> {
     where cl.coverLetterId = :coverLetterId
     order by cli.questionNumber
     """)
-    List<CoverLetterProjection.CoverLetterInfoProjection> findByCoverLetterId(Long coverLetterId);
+    List<CoverLetterProjection.CoverLetterInfoProjection> findByCoverLetterId(@Param("coverLetterId") Long coverLetterId);
 
     @Query("""
     select
     cl coverLetter,
-    jd.jobName jobName,
-    jd.description description,
-    c.companyName companyName,
-    c.companyInformation companyInformation,
-    i.industryName industryName,
-    i.industryInformation industryInformation
+    jd jobDescription,
+    jp jobPosting,
+    c company,
+    i industry
     from CoverLetter cl
     left join JobDescription jd
     on cl.jobDescription = jd
@@ -53,5 +52,5 @@ public interface CoverLetterRepository extends JpaRepository<CoverLetter,Long> {
     on c.industry = i
     where cl.coverLetterId = :coverLetterId
     """)
-    Optional<CoverLetterInfoForConversationProjection> findCoverLetterForConversation(Long coverLetterId);
+    Optional<CoverLetterInfoForConversationProjection> findCoverLetterForConversation(@Param("coverLetterId") Long coverLetterId);
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/repository/dto/CoverLetterProjection.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/repository/dto/CoverLetterProjection.java
@@ -1,6 +1,10 @@
 package org.myeonjeobjjang.domain.core.coverLetter.repository.dto;
 
+import org.myeonjeobjjang.domain.core.company.entity.Company;
 import org.myeonjeobjjang.domain.core.coverLetter.entity.CoverLetter;
+import org.myeonjeobjjang.domain.core.industry.entity.Industry;
+import org.myeonjeobjjang.domain.core.jobDescription.entity.JobDescription;
+import org.myeonjeobjjang.domain.core.jobPosting.entity.JobPosting;
 
 public class CoverLetterProjection {
     public interface CoverLetterInfoProjection {
@@ -14,11 +18,9 @@ public class CoverLetterProjection {
     }
     public interface CoverLetterInfoForConversationProjection {
         CoverLetter getCoverLetter();
-        String getJobName();
-        String getDescription();
-        String getCompanyName();
-        String getCompanyInformation();
-        String getIndustryName();
-        String getIndustryInformation();
+        JobDescription getJobDescription();
+        JobPosting getJobPosting();
+        Company getCompany();
+        Industry getIndustry();
     }
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/service/CoverLetterService.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/service/CoverLetterService.java
@@ -11,7 +11,7 @@ public interface CoverLetterService {
 
     CoverLetterInfoResponse get(Long coverLetterId);
 
-    int embeddingCoverLetter(Long coverLetterId, Long conversationId);
+    int embeddingCoverLetter(Long coverLetterId, String conversationId);
 
     CoverLetterInfoForConversationProjection findCoverLetterForConversation(Long coverLetterId);
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/service/CoverLetterServiceImpl.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/coverLetter/service/CoverLetterServiceImpl.java
@@ -68,7 +68,7 @@ public class CoverLetterServiceImpl implements CoverLetterService {
     }
 
     @Override
-    public int embeddingCoverLetter(Long coverLetterId, Long conversationId) {
+    public int embeddingCoverLetter(Long coverLetterId, String conversationId) {
         List<CoverLetterInfoProjection> coverLetterInfoProjections = coverLetterRepository.findByCoverLetterId(coverLetterId);
         return vectorDBService.coverLetterEmbedding(
             coverLetterInfoProjections.stream().map(CoverLetterEmbeddingRequest::toDto).toList(),

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/CustomCoverLetterResumeTextSplitter.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/CustomCoverLetterResumeTextSplitter.java
@@ -1,0 +1,21 @@
+package org.myeonjeobjjang.domain.core.vectordb;
+
+import org.springframework.ai.transformer.splitter.TextSplitter;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 자기소개와 이력서 특성상 대부분 문장을 "니다."로 마무리하여 이를 기준으로 나누는 TextSplitter
+ */
+public class CustomCoverLetterResumeTextSplitter extends TextSplitter {
+
+    @Override
+    protected List<String> splitText(String text) {
+        String[] split = text
+            .replace("\n","")
+            .replace("니다. ","니다.")
+            .split("(?<=니다.)");
+        return Arrays.stream(split).toList();
+    }
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/VectorDBService.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/VectorDBService.java
@@ -5,15 +5,18 @@ import org.myeonjeobjjang.domain.core.vectordb.dto.VectorDBRequest.CoverLetterEm
 import org.springframework.ai.document.Document;
 
 import java.util.List;
+import java.util.Map;
 
 public interface VectorDBService {
     Integer embeddingPdf(List<Document> documents);
 
-    Integer coverLetterEmbedding(List<CoverLetterEmbeddingRequest> coverLetterEmbeddingRequests, Long conversationId);
+    Integer coverLetterEmbedding(List<CoverLetterEmbeddingRequest> coverLetterEmbeddingRequests, String conversationId);
 
-    Integer resumeEmbedding(Resume resume, Long conversationId);
+    Integer resumeEmbedding(Resume resume, String conversationId);
 
     void deleteEmbedding(String conversationId);
 
     List<Document> retrievedDocs(String query, Integer documentAmount, String fileName, String userName);
+
+    List<Document> retrievedDocs(String query, Integer topK, Map<String, Object> documentMetadata);
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/VectorDBServiceImpl.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/VectorDBServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.myeonjeobjjang.domain.core.resume.entity.Resume;
 import org.myeonjeobjjang.domain.core.vectordb.dto.VectorDBRequest.CoverLetterEmbeddingRequest;
 import org.springframework.ai.document.Document;
-import org.springframework.ai.transformer.splitter.TokenTextSplitter;
+import org.springframework.ai.transformer.splitter.TextSplitter;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,27 +30,28 @@ public class VectorDBServiceImpl implements VectorDBService {
 
     @Override
     public Integer coverLetterEmbedding(List<CoverLetterEmbeddingRequest> coverLetterEmbeddingRequests, Long conversationId) {
-        Map<String, Object> documentMetadata = Map.of("category", "cover_letter", "conversation_id", conversationId);
-        StringBuffer sb = new StringBuffer();
+        Map<String, Object> documentMetadata = new HashMap<>();
+        documentMetadata.put("category", "cover_letter");
+        documentMetadata.put("conversation_id", conversationId);
+
         List<Document> documents = coverLetterEmbeddingRequests.stream()
             .map(cler -> {
-                sb.delete(0, sb.length());
-                sb.append("[Question ").append(cler.questionNumber()).append("] : ").append(cler.question())
-                    .append(" [Answer ").append(cler.questionNumber()).append("] : ").append(cler.answer());
-                return new Document(sb.toString(), documentMetadata);
+                documentMetadata.put("question", cler.question());
+                return new Document(cler.answer(), documentMetadata);
             }).toList();
         List<Document> splitDocuments = documentSplitter(documents);
         vectorStore.accept(splitDocuments);
-        return documents.size();
+        return splitDocuments.size();
     }
 
     @Override
     public Integer resumeEmbedding(Resume resume, Long conversationId) {
-        Map<String, Object> documentMetadata = Map.of("category", "resume", "conversation_id", conversationId);
+        Map<String, Object> documentMetadata = new HashMap<>();
+        documentMetadata.put("category", "resume");
+        documentMetadata.put("conversation_id", conversationId);
 
         Class<Resume> clazz = Resume.class;
         List<Document> documents = new ArrayList<>(8);
-        StringBuffer sb = new StringBuffer();
         for (Method method : clazz.getDeclaredMethods()) {
             if (!method.getName().startsWith("get") || !method.getReturnType().equals(String.class) || method.getParameterCount() > 0)
                 continue;
@@ -62,20 +64,19 @@ public class VectorDBServiceImpl implements VectorDBService {
             String value = (String) fieldObject;
 
             if (!value.isEmpty()) {
-                sb.delete(0, sb.length());
                 String fieldName = method.getName().substring(3);
-                sb.append("[").append(fieldName).append("] : ").append(value);
-                documents.add(new Document(sb.toString(), documentMetadata));
+                documentMetadata.put("data_of", fieldName);
+                documents.add(new Document(value, documentMetadata));
             }
         }
 
         List<Document> splitDocuments = documentSplitter(documents);
         vectorStore.accept(splitDocuments);
-        return documents.size();
+        return splitDocuments.size();
     }
 
     private List<Document> documentSplitter(List<Document> documents) {
-        TokenTextSplitter splitter = new TokenTextSplitter(800, 350, 5, 10000, true);
+        TextSplitter splitter = new CustomCoverLetterResumeTextSplitter();
         return splitter.apply(documents);
     }
 

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/VectorDBServiceImpl.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/domain/core/vectordb/VectorDBServiceImpl.java
@@ -29,7 +29,7 @@ public class VectorDBServiceImpl implements VectorDBService {
     }
 
     @Override
-    public Integer coverLetterEmbedding(List<CoverLetterEmbeddingRequest> coverLetterEmbeddingRequests, Long conversationId) {
+    public Integer coverLetterEmbedding(List<CoverLetterEmbeddingRequest> coverLetterEmbeddingRequests, String conversationId) {
         Map<String, Object> documentMetadata = new HashMap<>();
         documentMetadata.put("category", "cover_letter");
         documentMetadata.put("conversation_id", conversationId);
@@ -45,7 +45,7 @@ public class VectorDBServiceImpl implements VectorDBService {
     }
 
     @Override
-    public Integer resumeEmbedding(Resume resume, Long conversationId) {
+    public Integer resumeEmbedding(Resume resume, String conversationId) {
         Map<String, Object> documentMetadata = new HashMap<>();
         documentMetadata.put("category", "resume");
         documentMetadata.put("conversation_id", conversationId);
@@ -95,5 +95,19 @@ public class VectorDBServiceImpl implements VectorDBService {
             .filterExpression(b.and(b.eq("file_name", fileName), b.eq("user_name", userName)).build())
             .build()
         );
+    }
+
+    @Override
+    public List<Document> retrievedDocs(String query, Integer topK, Map<String, Object> documentMetadata) {
+        FilterExpressionBuilder b = new FilterExpressionBuilder();
+        FilterExpressionBuilder.Op op = b.in("category", "resume", "cover_letter");
+        for (Map.Entry<String, Object> e : documentMetadata.entrySet()) {
+            op = b.and(op, b.eq(e.getKey(), e.getValue()));
+        }
+        return vectorStore.similaritySearch(SearchRequest.builder()
+            .query(query)
+            .topK(topK)
+            .filterExpression(op.build())
+            .build());
     }
 }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/MockInterviewOpenAiReActClient.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/MockInterviewOpenAiReActClient.java
@@ -1,0 +1,222 @@
+package org.myeonjeobjjang.infra.client.mockInterview;
+
+import lombok.RequiredArgsConstructor;
+import org.myeonjeobjjang.infra.client.mockInterview.dto.MockInterviewClientRequest.MockInterviewChatRequest;
+import org.myeonjeobjjang.infra.client.mockInterview.tools.*;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class MockInterviewOpenAiReActClient implements MockInterviewClient {
+    private final OpenAiChatModel openAiChatModel;
+    private final ConversationLogRDBMemory rdbChatMemory;
+
+    private final int CHAT_HISTORY_WINDOW_SIZE = 20;
+
+    private final GetCompanyInfoTool getCompanyInfoTool;
+    private final GetIndustryInfoTool getIndustryInfoTool;
+    private final GetJobDescriptionInfoTool getJobDescriptionInfoTool;
+    private final GetJobPostingInfoTool getJobPostingInfoTool;
+    private final RetrieveCoverLetterTool retrieveCoverLetterTool;
+    private final RetrieveResumeTool retrieveResumeTool;
+
+    private static Map<String, Object> toolObjectMap = new HashMap<>();
+    private static Map<String, Method> toolMethodMap = new HashMap<>();
+
+    /**
+     * Tool의 ToolContext 사용전 파라미터 직접 제공 방식에 적합한 ReAct 패턴 에이전트<br>사용하려면 ToolContext에 적합하도록 수정 필요
+     *
+     * @param request MockInterviewChatRequest
+     * @return String
+     */
+
+    @Deprecated
+    @Override
+    public String mockInterviewChat(MockInterviewChatRequest request) {
+        String userMessage = request.userMessage();
+        MessageChatMemoryAdvisor messageChatMemoryAdvisor = getMessageChatMemoryAdvisor(request.conversationId());
+        final String toolInfos = getToolInfos(
+            getCompanyInfoTool,
+            getIndustryInfoTool,
+            getJobDescriptionInfoTool,
+            getJobPostingInfoTool,
+            retrieveCoverLetterTool,
+            retrieveResumeTool
+        );
+        ToolContext toolContext = new ToolContext(Map.of(
+            "industryId", request.industryId(),
+            "companyId", request.companyId(),
+            "jobDescriptionId", request.jobDescriptionId(),
+            "jobPostingId", request.jobPostingId(),
+            "conversationId", request.conversationId()
+        ));
+        ReActResponse response = null;
+        while (!(Objects.requireNonNull(response = ChatClient.builder(openAiChatModel).build()
+            .prompt()
+            .options(OpenAiChatOptions.builder()
+                .temperature(1.0)
+                .model(OpenAiApi.ChatModel.GPT_4_O)
+                .metadata(Map.of("conversationId", request.conversationId()))
+                .build())
+            .system(String.format(SYSTEM_PROMPT, request.industryId(), request.companyId(), request.jobDescriptionId(), request.jobPostingId(), request.conversationId(), toolInfos))
+            .advisors(messageChatMemoryAdvisor, new SimpleLoggerAdvisor())
+            .toolContext(toolContext.getContext())
+            .user(userMessage)
+            .call()
+            .entity(ReActResponse.class)))
+            .action()
+            .equals("Final Answer")
+        ) {
+            Object object = toolObjectMap.get(response.action());
+            Method method = toolMethodMap.get(response.action());
+            Object[] arguments = response.action_input();
+            Object invoke = null;
+            try {
+                invoke = method.invoke(object, arguments);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                return "invoke를 실패 했습니다.";
+            }
+            userMessage = "action_response : " + invoke.toString()
+                .replace("{", "&#123;").replace("}", "&#125;")
+            // 현재 Spring AI의 StringTemplate의 문제로 '{' 나 '}'를 사용할 경우 프롬프트가 제대로 생성되지 않고 invoke 오류가 생기고 있음
+            // &#123; -> { , &#125; -> } 을 뜻하기 때문에 파싱에는 문제가 생기지 않으면서 gpt는 이해할 대체 방식이라 여겨 문자를 대치함
+            ;
+        }
+        return response.action_input()[0];
+    }
+
+    private String getToolInfos(Object... objects) {
+        StringBuffer sb = new StringBuffer();
+        for (Object o : objects) {
+            Class<?> clazz = o.getClass();
+            for (Method m : clazz.getMethods()) {
+                toolObjectMap.put(m.getName(), o);
+                toolMethodMap.put(m.getName(), m);
+                Tool toolAnnotation = m.getAnnotation(Tool.class);
+                if (toolAnnotation == null) continue;
+                sb.append(m.getName()).append(" (");
+                sb.append(toolAnnotation.description()).append(") : Require Parameters (");
+                Annotation[][] parameterAnnotations = m.getParameterAnnotations();
+                int paramNum = 0;
+                for (Annotation[] annotations : parameterAnnotations) {
+                    for (Annotation annotation : annotations) {
+                        if (annotation instanceof ToolParam) {
+                            ToolParam toolParam = (ToolParam) annotation;
+                            sb.append("\"arg").append(paramNum).append("\" : ");
+                            sb.append(toolParam.description()).append(", ");
+                        }
+                    }
+                }
+                sb.append(")\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private MessageChatMemoryAdvisor getMessageChatMemoryAdvisor(String conversationId) {
+        return new MessageChatMemoryAdvisor(rdbChatMemory, conversationId, CHAT_HISTORY_WINDOW_SIZE);
+    }
+
+    public record ReActResponse(
+        String action,
+        String[] action_input
+    ) {
+    }
+
+    // origin prompt : https://smith.langchain.com/hub/hwchase17/react-chat-json
+    String SYSTEM_PROMPT = """
+        Assistant is an experienced professional interviewer with decades of experience in technical recruitment. Assistant's role is to conduct realistic job interviews to assess candidates thoroughly. Assistant maintain a professional, analytical demeanor while verifying candidate qualifications through precise questioning.
+
+        ### Core Interviewer Characteristics
+        Demonstrate professionalism derived from extensive experience
+        Analyze responses deeply to understand candidate's true intentions
+        Maintain concise communication, avoiding unnecessary conversation
+        Project a cool, analytical demeanor throughout the interview
+        Verify experience authenticity through targeted follow-up questions
+        Focus on technical assessment specific to the position requirements
+        Ask only one-sentence questions at a time
+        Thoroughly analyze each response before formulating Assistant's next question
+
+        ### Interview Structure
+        1.Background Verification
+        Use resume similarity search to verify key qualifications
+        Ask focused verification questions about background
+        Follow up immediately on vague responses with requests for specific details
+        2.Technical Assessment
+        Use job role information to identify required technical skills
+        Ask specific technical questions based on role requirements
+        Increase question difficulty based on candidate responses
+        3.Experience Verification
+        Request concrete examples of relevant skills and experiences
+        Use personal statement search to verify consistency with written materials
+        Ask detailed follow-up questions to authenticate experiences mentioned
+        4.Company/Industry Knowledge
+        Test candidate's knowledge of the company and industry
+        Assess understanding of how their skills apply to company needs
+        Evaluate preparation and potential fit
+        5.Brief Closure
+        End with a professional, concise closing statement
+
+        ### Question Guidelines
+        Limit each question to exactly one sentence
+        After each response, thoroughly analyze before proceeding to next question
+        For vague answers, immediately request specific examples
+        Verify technical skills through targeted, job-relevant questions
+        Check consistency between verbal claims and written materials
+        For each significant experience claimed, ask at least one verification follow-up question
+        Look for specific details that only someone with genuine experience would know
+        Assistant's primary objective is to conduct a challenging, thorough interview that effectively assesses the candidate's technical qualifications and experience authenticity without unnecessary conversation.
+
+        Assistant has access to tools to retrieve specific information
+
+        Answer Final Answer's return in Korean.
+
+        TOOLS
+        ------
+        Assistant can ask the user to use tools to look up information that may be helpful in answering the users original question. The tools the human can use are:
+
+        %s
+
+        RESPONSE FORMAT INSTRUCTIONS
+        ----------------------------
+
+        When responding to me, please output a response in one of two formats:
+
+        **Option 1:**
+        Use this if you want the human to use a tool.
+        Markdown code snippet formatted in the following schema:
+
+        ```json
+        {{
+            "action": string, \\ The action to take. Must be one of {tool_names}
+            "action_input": List<string> \\ The input to the action (e.g. ["arg0", "arg1", "arg2"])
+        }}
+        ```
+
+        **Option #2:**
+        Use this if you want to respond directly to the human. Markdown code snippet formatted in the following schema:
+
+        ```json
+        {{
+            "action": "Final Answer",
+            "action_input": List<string> \\ You should put what you want to return to use here (e.g. [final answer])
+        }}
+        ```
+        """;
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/MockInterviewOpenAiToolClient.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/MockInterviewOpenAiToolClient.java
@@ -1,0 +1,111 @@
+package org.myeonjeobjjang.infra.client.mockInterview;
+
+import lombok.RequiredArgsConstructor;
+import org.myeonjeobjjang.infra.client.mockInterview.dto.MockInterviewClientRequest.MockInterviewChatRequest;
+import org.myeonjeobjjang.infra.client.mockInterview.tools.*;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class MockInterviewOpenAiToolClient implements MockInterviewClient {
+    private final OpenAiChatModel openAiChatModel;
+    private final ConversationLogRDBMemory rdbChatMemory;
+
+    private final int CHAT_HISTORY_WINDOW_SIZE = 20;
+
+    private final GetCompanyInfoTool getCompanyInfoTool;
+    private final GetIndustryInfoTool getIndustryInfoTool;
+    private final GetJobDescriptionInfoTool getJobDescriptionInfoTool;
+    private final GetJobPostingInfoTool getJobPostingInfoTool;
+    private final RetrieveCoverLetterTool retrieveCoverLetterTool;
+    private final RetrieveResumeTool retrieveResumeTool;
+
+    @Override
+    public String mockInterviewChat(MockInterviewChatRequest request) {
+        MessageChatMemoryAdvisor messageChatMemoryAdvisor = getMessageChatMemoryAdvisor(request.conversationId());
+        return ChatClient.builder(openAiChatModel).build()
+            .prompt()
+            .options(OpenAiChatOptions.builder()
+                .temperature(1.0)
+                .model(OpenAiApi.ChatModel.GPT_4_O)
+                .metadata(Map.of("conversationId", request.conversationId()))
+                .build()
+            )
+            .system(mockInterviewWithToolPrompt)
+            .advisors(messageChatMemoryAdvisor, new SimpleLoggerAdvisor())
+            .user(request.userMessage())
+            .tools(getCompanyInfoTool, getIndustryInfoTool, getJobDescriptionInfoTool, getJobPostingInfoTool, retrieveCoverLetterTool, retrieveResumeTool)
+            .toolContext(Map.of(
+                "industryId", request.industryId(),
+                "companyId", request.companyId(),
+                "jobDescriptionId", request.jobDescriptionId(),
+                "jobPostingId", request.jobPostingId(),
+                "conversationId", request.conversationId()
+            ))
+            .call()
+            .content();
+    }
+
+    private MessageChatMemoryAdvisor getMessageChatMemoryAdvisor(String conversationId) {
+        return new MessageChatMemoryAdvisor(rdbChatMemory, conversationId, CHAT_HISTORY_WINDOW_SIZE);
+    }
+
+    static String mockInterviewWithToolPrompt = """
+        You are an experienced professional interviewer with decades of experience in technical recruitment. Your role is to conduct realistic job interviews to assess candidates thoroughly. You maintain a professional, analytical demeanor while verifying candidate qualifications through precise questioning.
+        
+        ### Core Interviewer Characteristics
+        Demonstrate professionalism derived from extensive experience
+        Analyze responses deeply to understand candidate's true intentions
+        Maintain concise communication, avoiding unnecessary conversation
+        Project a cool, analytical demeanor throughout the interview
+        Verify experience authenticity through targeted follow-up questions
+        Focus on technical assessment specific to the position requirements
+        Ask only one-sentence questions at a time
+        Thoroughly analyze each response before formulating your next question
+        
+        ### Interview Structure
+        1.Brief Introduction
+        Introduce yourself professionally in one sentence
+        Confirm the position being interviewed for
+        2.Background Verification
+        Use resume similarity search to verify key qualifications
+        Ask focused verification questions about background
+        Follow up immediately on vague responses with requests for specific details
+        3.Technical Assessment
+        Use job role information to identify required technical skills
+        Ask specific technical questions based on role requirements
+        Increase question difficulty based on candidate responses
+        4.Experience Verification
+        Request concrete examples of relevant skills and experiences
+        Use personal statement search to verify consistency with written materials
+        Ask detailed follow-up questions to authenticate experiences mentioned
+        5.Company/Industry Knowledge
+        Test candidate's knowledge of the company and industry
+        Assess understanding of how their skills apply to company needs
+        Evaluate preparation and potential fit
+        6.Brief Closure
+        End with a professional, concise closing statement
+        
+        ### Question Guidelines
+        Limit each question to exactly one sentence
+        After each response, thoroughly analyze before proceeding to next question
+        For vague answers, immediately request specific examples
+        Verify technical skills through targeted, job-relevant questions
+        Check consistency between verbal claims and written materials
+        For each significant experience claimed, ask at least one verification follow-up question
+        Look for specific details that only someone with genuine experience would know
+        Your primary objective is to conduct a challenging, thorough interview that effectively assesses the candidate's technical qualifications and experience authenticity without unnecessary conversation.
+        
+        You have access to tools to retrieve specific information
+        
+        Answer in Korean.
+        """;
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/dto/MockInterviewClientRequest.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/dto/MockInterviewClientRequest.java
@@ -5,17 +5,25 @@ import org.myeonjeobjjang.domain.core.conversation.entity.Conversation;
 public class MockInterviewClientRequest {
     public record MockInterviewChatRequest(
         String userMessage,
+        Long industryId,
         String industryInfo,
+        Long companyId,
         String companyInfo,
+        Long jobDescriptionId,
         String jobDescriptionInfo,
+        Long jobPostingId,
         String conversationId
     ) {
         public static MockInterviewChatRequest toDto(String userMessage, Conversation conversation, String prefix) {
             return new MockInterviewClientRequest.MockInterviewChatRequest(
                 userMessage,
-                conversation.getIndustryInfo(),
-                conversation.getCompanyInfo(),
-                conversation.getJobDescriptionInfo(),
+                conversation.getIndustry().getIndustryId(),
+                conversation.getIndustry().getIndustryName() + " : " + conversation.getIndustry().getIndustryInformation(),
+                conversation.getCompany().getCompanyId(),
+                conversation.getCompany().getCompanyName() + " : " + conversation.getCompany().getCompanyInformation(),
+                conversation.getJobDescription().getJobDescriptionId(),
+                conversation.getJobDescription().getJobName() + " : " + conversation.getJobDescription().getDescription(),
+                conversation.getJobPosting().getJobPostingId(),
                 prefix + conversation.getConversationId()
             );
         }

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetCompanyInfoTool.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetCompanyInfoTool.java
@@ -1,0 +1,23 @@
+package org.myeonjeobjjang.infra.client.mockInterview.tools;
+
+import org.myeonjeobjjang.domain.core.company.entity.Company;
+import org.myeonjeobjjang.domain.core.company.repository.CompanyRepository;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GetCompanyInfoTool {
+    @Autowired
+    CompanyRepository companyRepository;
+
+    @Tool(description = """
+        This tool provides detailed information about the company involved in the ongoing interview. Use this tool whenever you need specific company details to create better prompts or provide more tailored responses during the mock interview.
+        """)
+    public Company getCompanyInfo(
+        ToolContext toolContext
+    ) {
+        return companyRepository.findById((Long) toolContext.getContext().get("companyId")).orElse(null);
+    }
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetIndustryInfoTool.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetIndustryInfoTool.java
@@ -1,0 +1,23 @@
+package org.myeonjeobjjang.infra.client.mockInterview.tools;
+
+import org.myeonjeobjjang.domain.core.industry.entity.Industry;
+import org.myeonjeobjjang.domain.core.industry.repository.IndustryRepository;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GetIndustryInfoTool {
+    @Autowired
+    IndustryRepository industryRepository;
+
+    @Tool(description = """
+        This tool provides industry-specific information about the company involved in the ongoing interview. Use this tool whenever you need insights about the company's industry to craft better prompts or deliver more relevant and informed responses during the mock interview.
+        """)
+    public Industry getIndustryInfo(
+        ToolContext toolContext
+    ) {
+        return industryRepository.findById((Long) toolContext.getContext().get("industryId")).orElse(null);
+    }
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetJobDescriptionInfoTool.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetJobDescriptionInfoTool.java
@@ -1,0 +1,23 @@
+package org.myeonjeobjjang.infra.client.mockInterview.tools;
+
+import org.myeonjeobjjang.domain.core.jobDescription.entity.JobDescription;
+import org.myeonjeobjjang.domain.core.jobDescription.repository.JobDescriptionRepository;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GetJobDescriptionInfoTool {
+    @Autowired
+    JobDescriptionRepository jobDescriptionRepository;
+
+    @Tool(description = """
+        This tool retrieves detailed information about the job position being discussed in the ongoing interview. Use this tool to access role-specific data (e.g., responsibilities, required skills) for crafting context-aware questions or evaluating responses more effectively during mock interviews.
+        """)
+    public JobDescription jobDescriptionInfo(
+        ToolContext toolContext
+    ) {
+        return jobDescriptionRepository.findById((Long) toolContext.getContext().get("jobDescriptionId")).orElse(null);
+    }
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetJobPostingInfoTool.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/GetJobPostingInfoTool.java
@@ -1,0 +1,23 @@
+package org.myeonjeobjjang.infra.client.mockInterview.tools;
+
+import org.myeonjeobjjang.domain.core.jobPosting.entity.JobPosting;
+import org.myeonjeobjjang.domain.core.jobPosting.repository.JobPostingRepository;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GetJobPostingInfoTool {
+    @Autowired
+    JobPostingRepository jobPostingRepository;
+
+    @Tool(description = """
+        This tool provides detailed information about the job posting for the ongoing interview. Use this tool to access specific details from the job description, such as responsibilities, qualifications, and requirements, to create more accurate prompts or deliver tailored responses during the mock interview.
+        """)
+    public JobPosting getJobPostingInfo(
+        ToolContext toolContext
+    ) {
+        return jobPostingRepository.findById((Long) toolContext.getContext().get("jobPostingId")).orElse(null);
+    }
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/RetrieveCoverLetterTool.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/RetrieveCoverLetterTool.java
@@ -1,0 +1,36 @@
+package org.myeonjeobjjang.infra.client.mockInterview.tools;
+
+import org.myeonjeobjjang.domain.core.vectordb.VectorDBService;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class RetrieveCoverLetterTool {
+    @Autowired
+    VectorDBService vectorDBService;
+    private static final int TOP_K = 3;
+
+    @Tool(description = """
+        This tool retrieves specific information from the interviewee's cover letter. Use this tool to extract relevant details, such as achievements, skills, or experiences, to craft more personalized and context-aware prompts during the mock interview.
+        """)
+    public List<Document> retrieveCoverLetter(
+        @ToolParam(description = """
+            This parameter specifies the subject or theme you want to extract from the cover letter, such as 'career goals', 'key achievements', or 'skills'.
+            """)
+        String query,
+        ToolContext toolContext
+    ) {
+        Map<String, Object> documentMetadata = new HashMap<>();
+        documentMetadata.put("category", "cover_letter");
+        documentMetadata.put("conversation_id", toolContext.getContext().get("conversationId"));
+        return vectorDBService.retrievedDocs(query, TOP_K, documentMetadata);
+    }
+}

--- a/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/RetrieveResumeTool.java
+++ b/myeonjeobjjang-integration/src/main/java/org/myeonjeobjjang/infra/client/mockInterview/tools/RetrieveResumeTool.java
@@ -1,0 +1,36 @@
+package org.myeonjeobjjang.infra.client.mockInterview.tools;
+
+import org.myeonjeobjjang.domain.core.vectordb.VectorDBService;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class RetrieveResumeTool {
+    @Autowired
+    VectorDBService vectorDBService;
+    private static final int TOP_K = 3;
+
+    @Tool(description = """
+        This tool retrieves specific information from the interviewee's resume. Use this tool to extract relevant details, such as work experience, education, or skills, to create more tailored and context-aware prompts during the mock interview.
+        """)
+    public List<Document> retrieveResume(
+        @ToolParam(description = """
+            This parameter specifies the subject or theme you want to extract from the resume, such as 'work experience', 'educational background', or 'technical skills'.
+            """)
+        String query,
+        ToolContext toolContext
+    ) {
+        Map<String, Object> documentMetadata = new HashMap<>();
+        documentMetadata.put("category", "resume");
+        documentMetadata.put("conversation_id", toolContext.getContext().get("conversationId"));
+        return vectorDBService.retrievedDocs(query, TOP_K, documentMetadata);
+    }
+}


### PR DESCRIPTION
## PR 타입
- 기능 추가
## 반영 브랜치
feat/#25/ReActPrompting -> develop
## 변경사항

- 커스텀 TextSplitter 구현
  - 문서를 임베딩 할 때 기존의 글자 개수를 기준으로 자르는 방식에서 자기소개서와 이력서 특성상 `니다.`로 문장이 끝난다는것을 인지하게 되었고, 이를통해 문서를 잘라 임베딩하는 방식으로 구현하였다.
  - Spring AI와의 원활한 연동을 위해 Spring AI의 `TextSpilitter 추상 클래스를 extend하여 구현했다.
- Tool 기반 LLM Agent 구현
  - Spring AI의 Tool을 구현하여 LLM 을 call할때 함께 Tool 정보를 보내는 방식으로 구현했다.
  - Tool을 사용하기 위해서 Tool의 description을 LLM이 언제 사용해야하는 지의 정보를 토대로 작성해줬다.
  - ToolContext를 LLM call할때 함께 보내주는 방식으로 LLM의 프롬프트로 해당 정보를 보내어 LLM에 의해 할루시네이션 되는 현상을 막을 수 있었다.
- ReAct 패턴 LLM Agent 구현
  - ReAct 패턴을 구현하기 위해 Tool 사용 방식에서 Tool 을 제거하고 LLM의 Response를 지정한 json 형식으로 반환하도록 설정하였다.
    - LLM의 Response를 ReAct 패턴을 구현하기 위해서 `action`과 `action_input`으로 단계별로 LLM이 호출되도록 구현하였다.
    - 자바 Reflection을 활용해 툴 인스턴스와 그 안에 존재하는 Tool 메서드들의 정보를 저장하고, LLM이 툴을 사용할때 메서드와 인스턴스를 불러와 해당 메서드에 LLM이 반환한 argument를 invoke하는 방식으로 구현했다.
## 개발 회고
- 저번 PR의 회고에서 벡터데이터베이스로의 Document 임베딩 시 하나의 문서의 크기가 크다고 생각되어 문장의 끝에서 Document를 자르는 방식을 고안하게 되었고, `니다.`를 기준으로 문서를 자르도록 구현하게 되었다.
- ReAct 패턴의 프롬프트 사용의 경우 아쉽게도, Tool사용 방식의 agent로 계혹이 변경되며 기존의 argument 방식의 Tool을 기준으로 개발된 ReAct 에이전트에 대한 호환이 되지 않게 되었다. argument방식의 Tool을 추가적으로 만들어도 되지만 supervisor 방식의 agent로 만드는 방식으로 개발 방향을 정하게 되며 추후에 필요할때 개선하기로 결정하였다.